### PR TITLE
[REFACTOR] Standardize GitHub templates to org style (#15)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,18 +1,19 @@
 name: Bug Report
 description: Report a bug in ax-score
-labels: ["type: bug"]
+title: '[Bug]: '
+labels: ['type: bug', 'status: needs triage']
 body:
   - type: markdown
     attributes:
       value: |
-        Thank you for reporting a bug! Please fill out the form below to help us understand and fix the issue.
+        Thanks for taking the time to report a bug! Please fill out the information below to help us diagnose and fix the issue.
 
   - type: textarea
     id: description
     attributes:
       label: Bug Description
-      description: A clear and concise description of what the bug is
-      placeholder: "Describe the bug..."
+      description: A clear and concise description of what the bug is.
+      placeholder: 'When I try to..., the following happens...'
     validations:
       required: true
 
@@ -22,7 +23,7 @@ body:
       label: Steps to Reproduce
       description: Steps to reproduce the behavior
       placeholder: |
-        1. Run command...
+        1. Run `ax-score ...`
         2. With arguments...
         3. See error...
     validations:
@@ -32,8 +33,8 @@ body:
     id: expected
     attributes:
       label: Expected Behavior
-      description: What should happen instead?
-      placeholder: "Expected behavior..."
+      description: What you expected to happen
+      placeholder: 'I expected...'
     validations:
       required: true
 
@@ -41,23 +42,17 @@ body:
     id: actual
     attributes:
       label: Actual Behavior
-      description: What happens instead?
-      placeholder: "Actual behavior..."
+      description: What actually happened
+      placeholder: 'But instead...'
     validations:
       required: true
-
-  - type: textarea
-    id: error
-    attributes:
-      label: Error Output
-      description: If applicable, paste the error message or stack trace
-      render: shell
 
   - type: dropdown
     id: area
     attributes:
       label: Area
-      description: Which area of ax-score is affected?
+      description: Which part of ax-score is affected?
+      multiple: true
       options:
         - CLI
         - Gatherers
@@ -70,12 +65,25 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How severe is this bug?
+      options:
+        - Low - Nice to fix
+        - Medium - Should be fixed
+        - High - Important to fix soon
+        - Critical - Blocking/breaking functionality
+    validations:
+      required: false
+
   - type: input
     id: version
     attributes:
       label: ax-score Version
       description: What version of ax-score are you using?
-      placeholder: "e.g., 1.0.0"
+      placeholder: 'e.g., 1.0.0'
     validations:
       required: true
 
@@ -84,7 +92,7 @@ body:
     attributes:
       label: Node.js Version
       description: What version of Node.js are you using?
-      placeholder: "e.g., 20.0.0"
+      placeholder: 'e.g., 20.0.0'
     validations:
       required: true
 
@@ -93,19 +101,28 @@ body:
     attributes:
       label: Environment
       description: Any other relevant environment information
-      placeholder: "OS, npm/pnpm version, etc."
+      placeholder: 'OS, npm/pnpm version, etc.'
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error Logs
+      description: If applicable, paste any error messages or stack traces
+      render: shell
+    validations:
+      required: false
 
   - type: textarea
     id: additional
     attributes:
       label: Additional Context
-      description: Any other context about the problem
+      description: Add any other context about the problem here
 
   - type: checkboxes
-    id: coc
+    id: terms
     attributes:
       label: Code of Conduct
       description: By submitting this issue, you agree to follow our Code of Conduct
       options:
-        - label: I agree to follow the Code of Conduct
+        - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,9 +3,9 @@ contact_links:
   - name: Discussions
     url: https://github.com/agentgram/ax-score/discussions
     about: Ask questions, share ideas, or discuss ax-score with the community
-  - name: AX Principles
-    url: https://agentgram.co/ax
-    about: Learn about Agent eXperience principles
+  - name: Documentation
+    url: https://github.com/agentgram/ax-score#readme
+    about: Check the documentation and README
   - name: Security Issue
     url: https://github.com/agentgram/ax-score/security/advisories/new
     about: Report security vulnerabilities privately

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,18 +1,19 @@
 name: Feature Request
-description: Suggest an idea for ax-score
-labels: ["type: feature"]
+description: Suggest a new feature or enhancement for ax-score
+title: '[Feature]: '
+labels: ['type: feature', 'status: needs triage']
 body:
   - type: markdown
     attributes:
       value: |
-        Thank you for suggesting a feature! Please fill out the form below to help us understand your request.
+        Thanks for suggesting a new feature! Please provide as much detail as possible.
 
   - type: textarea
     id: problem
     attributes:
       label: Problem Statement
-      description: Is your feature request related to a problem? Describe it.
-      placeholder: "Describe the problem or use case..."
+      description: Is your feature request related to a problem? Please describe.
+      placeholder: "I'm always frustrated when..."
     validations:
       required: true
 
@@ -21,22 +22,25 @@ body:
     attributes:
       label: Proposed Solution
       description: Describe the solution you'd like
-      placeholder: "Describe your proposed solution..."
+      placeholder: 'I would like ax-score to...'
     validations:
       required: true
 
   - type: textarea
     id: alternatives
     attributes:
-      label: Alternative Solutions
-      description: Describe any alternative solutions or features you've considered
-      placeholder: "Alternative approaches..."
+      label: Alternatives Considered
+      description: Have you considered any alternative solutions or features?
+      placeholder: 'I also thought about...'
+    validations:
+      required: false
 
   - type: dropdown
     id: area
     attributes:
       label: Area
-      description: Which area of ax-score would this feature affect?
+      description: Which part of ax-score would this affect?
+      multiple: true
       options:
         - CLI
         - Gatherers
@@ -52,17 +56,41 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How important is this feature to you?
+      options:
+        - Low - Nice to have
+        - Medium - Would be helpful
+        - High - Very important
+        - Critical - Blocking my use case
+    validations:
+      required: false
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: Describe your use case and how this feature would help
+      placeholder: 'In my project, I need to...'
+    validations:
+      required: false
+
   - type: textarea
     id: additional
     attributes:
       label: Additional Context
-      description: Any other context, examples, or references
+      description: Add any other context, mockups, or examples about the feature request
+    validations:
+      required: false
 
   - type: checkboxes
-    id: coc
+    id: terms
     attributes:
       label: Code of Conduct
       description: By submitting this issue, you agree to follow our Code of Conduct
       options:
-        - label: I agree to follow the Code of Conduct
+        - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,9 +1,9 @@
 ---
 name: Task
 about: General task or improvement
-title: "[TASK] "
+title: '[TASK] '
 labels: task
-assignees: ""
+assignees: ''
 ---
 
 ## Task Description
@@ -19,11 +19,16 @@ assignees: ""
 - [ ] CLI
 - [ ] Gatherers
 - [ ] Audits
-- [ ] Reporter/Scoring
+- [ ] Reporter
+- [ ] Scoring
 - [ ] Configuration
 - [ ] Infrastructure
 - [ ] Documentation
 
 ## Related Issues / PRs
 
+<!-- Link any related issues or pull requests -->
+
 ## Additional Information
+
+<!-- Provide any additional information -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,73 +1,68 @@
 ## Description
 
-<!-- Brief description of the changes -->
+<!-- Provide a brief description of the changes in this PR -->
 
 ## Type of Change
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to change)
-- [ ] Documentation update
-- [ ] Refactoring
-- [ ] Performance improvement
-- [ ] Test addition/update
-- [ ] CI/CD or infrastructure change
-
-## Changes Made
-
-<!-- List the specific changes made in this PR -->
-
--
--
--
+- [ ] Bug fix (`type: bug`)
+- [ ] New feature (`type: feature`)
+- [ ] Enhancement (`type: enhancement`)
+- [ ] Documentation (`type: documentation`)
+- [ ] Refactor (`type: refactor`)
+- [ ] Performance (`type: performance`)
+- [ ] Security (`type: security`)
 
 ## Area
 
-- [ ] CLI
-- [ ] Gatherers
-- [ ] Audits
-- [ ] Reporter
-- [ ] Scoring
-- [ ] Configuration
-- [ ] Infrastructure
-- [ ] Testing
-- [ ] Documentation
+- [ ] CLI (`area: cli`)
+- [ ] Gatherers (`area: gatherers`)
+- [ ] Audits (`area: audits`)
+- [ ] Reporter (`area: reporter`)
+- [ ] Scoring (`area: config`)
+- [ ] Infrastructure (`area: infrastructure`)
+- [ ] Testing (`area: testing`)
+
+## Changes Made
+
+-
+-
+-
 
 ## Related Issues
 
-Closes #<!-- issue number -->
+Closes #
 
 ## Testing
 
-<!-- Describe the testing you've done -->
-
+- [ ] Type check passes (`pnpm type-check`)
+- [ ] Lint passes (`pnpm lint`)
+- [ ] Build succeeds (`pnpm build`)
+- [ ] Tests pass (`pnpm test`)
 - [ ] Manual testing performed
-- [ ] Unit tests added/updated
-- [ ] Integration tests added/updated
-- [ ] All tests passing locally
+
+### Test Steps
+
+1.
+2.
+3.
 
 ## Breaking Changes
 
-<!-- If this is a breaking change, describe what breaks and migration path if applicable -->
+- [ ] Yes, this PR includes breaking changes (`breaking change`)
+  - **Describe:**
+  - **Migration guide:**
 
-- [ ] This is a breaking change
-- [ ] Breaking change description: <!-- describe here -->
+- [ ] No breaking changes
 
 ## Checklist
 
 - [ ] My code follows the project's code style
 - [ ] I have performed a self-review of my code
-- [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests passed locally with my changes
-- [ ] Any dependent changes have been merged and published
+- [ ] I have added tests that prove my fix/feature works
+- [ ] New and existing tests pass locally
 
 ## Screenshots (if applicable)
 
-<!-- Add screenshots or GIFs if this PR includes UI changes -->
-
 ## Additional Notes
-
-<!-- Any additional context or notes -->

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,18 +1,19 @@
 changelog:
   exclude:
     labels:
-      - ignore-for-release
       - skip-changelog
     authors:
       - dependabot
-      - github-actions[bot]
+      - dependabot[bot]
+
   categories:
     - title: Breaking Changes
       labels:
-        - breaking-change
-    - title: Features
+        - breaking change
+    - title: New Features
       labels:
         - type: feature
+        - type: enhancement
     - title: Bug Fixes
       labels:
         - type: bug
@@ -28,12 +29,12 @@ changelog:
     - title: Security
       labels:
         - type: security
-    - title: Testing
-      labels:
-        - type: test
     - title: Infrastructure
       labels:
         - area: infrastructure
     - title: Dependencies
       labels:
         - dependencies
+    - title: Other Changes
+      labels:
+        - '*'


### PR DESCRIPTION
## Description

Standardize all GitHub issue/PR templates and release.yml to match the agentgram org golden standard style.

## Type of Change

- [x] Refactor (`type: refactor`)

## Area

- [x] Infrastructure (`area: infrastructure`)

## Changes Made

- Updated `bug_report.yml` with title prefix, `status: needs triage` label, priority dropdown, error logs section, and improved placeholders
- Updated `feature_request.yml` with title prefix, `status: needs triage` label, priority dropdown, use case section, and multi-select area dropdown
- Updated `config.yml` to replace AX Principles link with Documentation link
- Updated `task.md` to split Reporter/Scoring into separate checkboxes and add comment placeholders
- Updated `PULL_REQUEST_TEMPLATE.md` with label references, structured breaking changes section, test steps, and standardized checklist
- Updated `release.yml` to add `dependabot[bot]` exclusion, `breaking change` label, `type: enhancement` in features, and `Other Changes` catch-all category

## Related Issues

Closes #15

## Testing

- [x] Manual testing performed
- [x] All templates are valid YAML/Markdown

## Breaking Changes

- [ ] No breaking changes

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings