### PR TITLE
[FIX] Resolve pnpm version mismatch in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Description

Fixes the pnpm version mismatch error in the publish workflow. The workflow was specifying version 10 while package.json specifies pnpm@10.4.1, causing the publish step to fail.

## Changes

- Remove explicit version specification from pnpm action setup
- Let pnpm action use the version from package.json

## Testing

- Publish workflow should now complete successfully