### PR TITLE
[RELEASE] Merge develop to main - v0.0.2 release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Description

Merge develop branch to main to trigger automatic v0.0.2 release and npm publish.

## Changes

- Fix pnpm version mismatch in publish workflow (PR #20)

## Testing

- Auto-release workflow will create v0.0.2 tag and release
- Publish workflow will deploy to npm