### PR TITLE
[FEAT] Update npm publish workflow to trigger on tag pushes (#23)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish to npm
 
 on:
+  push:
+    tags:
+      - 'v*'
   release:
     types: [published]
 


### PR DESCRIPTION
## Description

This PR updates the npm publish workflow to trigger on tag pushes matching the pattern `v*` (e.g., v0.0.3, v1.0.0) in addition to the existing release trigger.

## Type of Change

- [x] Feature (new functionality)

## Changes Made

- Added `push` trigger with `tags: ['v*']` to .github/workflows/publish.yml
- Kept existing `release: [published]` trigger for manual releases
- Ensures npm publishes whenever a version tag is pushed

## Related Issues

Closes #23

## Testing

- [x] Workflow YAML is valid
- [x] Trigger configuration matches Git Flow conventions
- [x] Node 20 + pnpm 10 config preserved
- [x] npm auth via NODE_AUTH_TOKEN preserved

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] Changes are minimal and focused
- [x] No unrelated files modified