### PR TITLE
[FEAT] Update npm publish workflow to trigger on tag pushes (#23)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish to npm
 
 on:
+  push:
+    tags:
+      - 'v*'
   release:
     types: [published]
 


### PR DESCRIPTION
## Description

This release PR merges the npm publish workflow update from develop to main. The workflow now triggers on tag pushes matching the pattern `v*` in addition to the existing release trigger.

## Type of Change

- [x] Feature (new functionality)

## Changes Made

- Added `push` trigger with `tags: ['v*']` to .github/workflows/publish.yml
- Kept existing `release: [published]` trigger for manual releases
- Ensures npm publishes whenever a version tag is pushed

## Related Issues

Closes #23

## Testing

- [x] Workflow YAML is valid
- [x] Merged to develop successfully (PR #24)
- [x] Ready for production release

## Checklist

- [x] All changes from develop are included
- [x] Workflow is present and valid on develop
- [x] Ready to merge to main for production