### PR TITLE
[FIX] Trigger publish workflow from auto-release (#47)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   auto-release:
@@ -133,6 +134,14 @@ jobs:
 
           echo "Release ${VERSION} published successfully!"
           echo "https://github.com/${{ github.repository }}/releases/tag/${VERSION}"
+
+      - name: Trigger publish workflow
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run publish.yml
+          echo "Publish workflow triggered"
 
       - name: Skip (tag exists)
         if: steps.check.outputs.exists == 'true'


### PR DESCRIPTION
## Description

Fix the auto-publish chain where `publish.yml` was never triggered after `auto-release.yml` created a release. This is a known GitHub Actions limitation: events created with the default `GITHUB_TOKEN` do not trigger other workflows.

The fix uses `gh workflow run publish.yml` (workflow_dispatch), which is an exception to this limitation and works with `GITHUB_TOKEN`.

## Type of Change

- [x] Bug fix

## Changes Made

- Added "Trigger publish workflow" step to `auto-release.yml` that calls `gh workflow run publish.yml` after creating a release
- Added `actions: write` permission required by `gh workflow run`

## Related Issues

Closes #47

## Testing

- [ ] Manual testing performed
- [x] Verified `publish.yml` already has `workflow_dispatch` trigger
- [x] Verified the new step has the correct `if` condition (`steps.check.outputs.exists == 'false'`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings