### PR TITLE
feat: classify site type and adapt scoring profile

### DIFF
--- a/src/classifiers/__tests__/site-type.test.ts
+++ b/src/classifiers/__tests__/site-type.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import { classifySiteType } from '../site-type.js';
+import type { HttpGatherResult, FileProbe } from '../../gatherers/http-gatherer.js';
+import type { HtmlGatherResult } from '../../gatherers/html-gatherer.js';
+import type { GatherResult } from '../../gatherers/base-gatherer.js';
+
+const EMPTY_PROBE: FileProbe = { found: false, content: null, statusCode: null };
+
+function makeArtifacts(
+  httpOverrides: Partial<HttpGatherResult> = {},
+  htmlOverrides: Partial<HtmlGatherResult> = {}
+): Record<string, GatherResult> {
+  const http: HttpGatherResult = {
+    url: 'https://example.com',
+    statusCode: 200,
+    headers: {},
+    body: '<html><body>hello</body></html>',
+    robotsTxt: EMPTY_PROBE,
+    llmsTxt: EMPTY_PROBE,
+    openapiSpec: EMPTY_PROBE,
+    aiPlugin: EMPTY_PROBE,
+    sitemapXml: EMPTY_PROBE,
+    securityTxt: EMPTY_PROBE,
+    ...httpOverrides,
+  };
+
+  const html: HtmlGatherResult = {
+    html: http.body,
+    jsonLd: [],
+    metaTags: {
+      title: null,
+      description: null,
+      ogTitle: null,
+      ogDescription: null,
+      ogImage: null,
+      canonical: null,
+      robots: null,
+    },
+    semanticElements: {
+      hasNav: false,
+      hasMain: false,
+      hasArticle: false,
+      hasHeader: false,
+      hasFooter: false,
+      hasH1: false,
+      headingCount: 0,
+    },
+    links: [],
+    ...htmlOverrides,
+  };
+
+  return { http, html };
+}
+
+describe('classifySiteType', () => {
+  it('should classify a content site with article tags', () => {
+    const artifacts = makeArtifacts(
+      {},
+      {
+        semanticElements: {
+          hasNav: true,
+          hasMain: true,
+          hasArticle: true,
+          hasHeader: true,
+          hasFooter: true,
+          hasH1: true,
+          headingCount: 8,
+        },
+        jsonLd: [{ '@type': 'WebSite', name: 'Blog' }],
+        metaTags: {
+          title: 'My Blog',
+          description: 'A tech blog',
+          ogTitle: null,
+          ogDescription: null,
+          ogImage: null,
+          canonical: null,
+          robots: null,
+        },
+      }
+    );
+
+    const result = classifySiteType(artifacts);
+    expect(result.type).toBe('content');
+    expect(result.signals.content.length).toBeGreaterThan(0);
+  });
+
+  it('should classify an API service with OpenAPI spec', () => {
+    const artifacts = makeArtifacts({
+      openapiSpec: { found: true, content: '{"openapi":"3.0.0"}', statusCode: 200 },
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const result = classifySiteType(artifacts);
+    expect(result.type).toBe('api');
+    expect(result.signals.api).toContain('OpenAPI spec found');
+    expect(result.signals.api).toContain('main page returns JSON');
+  });
+
+  it('should classify hybrid when both signals are present', () => {
+    const artifacts = makeArtifacts(
+      {
+        openapiSpec: { found: true, content: '{"openapi":"3.0.0"}', statusCode: 200 },
+      },
+      {
+        semanticElements: {
+          hasNav: true,
+          hasMain: true,
+          hasArticle: true,
+          hasHeader: true,
+          hasFooter: true,
+          hasH1: true,
+          headingCount: 10,
+        },
+        jsonLd: [{ '@type': 'BlogPosting', headline: 'Post' }],
+      }
+    );
+
+    const result = classifySiteType(artifacts);
+    expect(result.type).toBe('hybrid');
+    expect(result.signals.content.length).toBeGreaterThan(0);
+    expect(result.signals.api.length).toBeGreaterThan(0);
+  });
+
+  it('should return unknown for minimal sites', () => {
+    const artifacts = makeArtifacts();
+
+    const result = classifySiteType(artifacts);
+    expect(result.type).toBe('unknown');
+  });
+
+  it('should detect content via JSON-LD BlogPosting', () => {
+    const artifacts = makeArtifacts(
+      {},
+      {
+        jsonLd: [{ '@type': 'BlogPosting', headline: 'Test' }],
+      }
+    );
+
+    const result = classifySiteType(artifacts);
+    // BlogPosting alone (2 pts) < threshold (3), so depends on other signals
+    expect(['content', 'unknown']).toContain(result.type);
+  });
+
+  it('should detect API via robots.txt API paths', () => {
+    const artifacts = makeArtifacts({
+      robotsTxt: {
+        found: true,
+        content: 'User-agent: *\nDisallow: /api/v1/admin\nDisallow: /v2/internal',
+        statusCode: 200,
+      },
+    });
+
+    const result = classifySiteType(artifacts);
+    expect(result.signals.api).toContain('robots.txt references API paths');
+  });
+
+  it('should detect API via links to API paths', () => {
+    const artifacts = makeArtifacts(
+      {},
+      {
+        links: ['https://example.com/api/v1/users', 'https://example.com/docs'],
+      }
+    );
+
+    const result = classifySiteType(artifacts);
+    expect(result.signals.api.length).toBeGreaterThan(0);
+    expect(result.signals.api.some((s) => s.includes('API paths'))).toBe(true);
+  });
+});

--- a/src/classifiers/site-type.ts
+++ b/src/classifiers/site-type.ts
@@ -1,0 +1,170 @@
+import type { SiteType } from '../types.js';
+import type { GatherResult } from '../gatherers/base-gatherer.js';
+import type { HttpGatherResult } from '../gatherers/http-gatherer.js';
+import type { HtmlGatherResult } from '../gatherers/html-gatherer.js';
+
+export interface SiteTypeResult {
+  type: SiteType;
+  confidence: number; // 0-1
+  signals: {
+    content: string[];
+    api: string[];
+  };
+}
+
+/**
+ * Classifies a site as 'api', 'content', 'hybrid', or 'unknown' based on
+ * signals from gathered artifacts.
+ *
+ * Signals are weighted and tallied independently for content and API.
+ * If both scores are significant → hybrid.
+ * If one dominates → that type.
+ * If neither → unknown.
+ */
+export function classifySiteType(
+  artifacts: Record<string, GatherResult>
+): SiteTypeResult {
+  const http = artifacts['http'] as HttpGatherResult | undefined;
+  const html = artifacts['html'] as HtmlGatherResult | undefined;
+
+  const contentSignals: string[] = [];
+  const apiSignals: string[] = [];
+
+  let contentScore = 0;
+  let apiScore = 0;
+
+  // --- Content signals ---
+  if (html) {
+    // <article> is a strong content indicator
+    if (html.semanticElements.hasArticle) {
+      contentSignals.push('has <article> elements');
+      contentScore += 3;
+    }
+
+    // Many headings suggest rich content
+    if (html.semanticElements.headingCount >= 5) {
+      contentSignals.push(`many headings (${html.semanticElements.headingCount})`);
+      contentScore += 1;
+    }
+
+    // JSON-LD with content-related types
+    const jsonLd = html.jsonLd;
+    if (Array.isArray(jsonLd)) {
+      const contentTypes = new Set([
+        'WebSite', 'WebPage', 'Article', 'BlogPosting',
+        'NewsArticle', 'TechArticle', 'ScholarlyArticle',
+        'Recipe', 'HowTo', 'FAQPage', 'BreadcrumbList',
+      ]);
+      for (const block of jsonLd) {
+        const blockType = getBlockType(block);
+        if (contentTypes.has(blockType)) {
+          contentSignals.push(`JSON-LD type: ${blockType}`);
+          contentScore += 2;
+          break; // one match is enough
+        }
+      }
+    }
+
+    // Large HTML body (content-rich pages tend to be larger)
+    if (html.html.length > 10_000) {
+      contentSignals.push('large HTML body (>10KB)');
+      contentScore += 1;
+    }
+
+    // Meta description present (content sites usually have these)
+    if (html.metaTags.description) {
+      contentSignals.push('has meta description');
+      contentScore += 1;
+    }
+
+    // Semantic structure (nav, main, header, footer)
+    const semCount = [
+      html.semanticElements.hasNav,
+      html.semanticElements.hasMain,
+      html.semanticElements.hasHeader,
+      html.semanticElements.hasFooter,
+    ].filter(Boolean).length;
+
+    if (semCount >= 3) {
+      contentSignals.push(`strong semantic structure (${semCount}/4)`);
+      contentScore += 1;
+    }
+  }
+
+  // --- API signals ---
+  if (http) {
+    // OpenAPI spec found → strong API indicator
+    if (http.openapiSpec.found) {
+      apiSignals.push('OpenAPI spec found');
+      apiScore += 4;
+    }
+
+    // robots.txt references API paths
+    if (http.robotsTxt.content) {
+      const robots = http.robotsTxt.content.toLowerCase();
+      if (robots.includes('/api/') || robots.includes('/v1/') || robots.includes('/v2/')) {
+        apiSignals.push('robots.txt references API paths');
+        apiScore += 1;
+      }
+    }
+
+    // Response content-type is JSON
+    const contentType = http.headers['content-type'] ?? '';
+    if (contentType.includes('application/json')) {
+      apiSignals.push('main page returns JSON');
+      apiScore += 3;
+    }
+  }
+
+  if (html) {
+    // Links containing /api/ paths
+    const apiLinks = html.links.filter(
+      (l) => /\/api\/|\/v[0-9]+\/|\/graphql/i.test(l)
+    );
+    if (apiLinks.length > 0) {
+      apiSignals.push(`links to API paths (${apiLinks.length})`);
+      apiScore += 2;
+    }
+  }
+
+  // --- Classification ---
+  const threshold = 3; // minimum score to consider a type
+  const isContent = contentScore >= threshold;
+  const isApi = apiScore >= threshold;
+
+  let type: SiteType;
+  if (isContent && isApi) {
+    type = 'hybrid';
+  } else if (isContent) {
+    type = 'content';
+  } else if (isApi) {
+    type = 'api';
+  } else {
+    type = 'unknown';
+  }
+
+  // Confidence: ratio of winning score to total possible
+  const maxScore = Math.max(contentScore + apiScore, 1);
+  const confidence = Math.min(
+    Math.max(contentScore, apiScore) / maxScore,
+    1
+  );
+
+  return {
+    type,
+    confidence: Math.round(confidence * 100) / 100,
+    signals: {
+      content: contentSignals,
+      api: apiSignals,
+    },
+  };
+}
+
+function getBlockType(block: unknown): string {
+  if (typeof block !== 'object' || block === null) return '';
+  const obj = block as Record<string, unknown>;
+  const t = obj['@type'];
+  if (typeof t === 'string') return t;
+  if (Array.isArray(t) && t.length > 0) return String(t[0]);
+  return '';
+}

--- a/src/config/__tests__/default.test.ts
+++ b/src/config/__tests__/default.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { getCategoriesForSiteType, DEFAULT_CATEGORIES } from '../default.js';
+
+describe('getCategoriesForSiteType', () => {
+  it('should zero out API-only audits for content sites', () => {
+    const contentCats = getCategoriesForSiteType('content');
+
+    // API-only audits should have weight 0
+    const apiOnlyIds = [
+      'openapi-spec', 'openapi-valid', 'response-format',
+      'response-examples', 'content-negotiation', 'self-service-auth',
+      'error-codes', 'rate-limit-headers', 'retry-after', 'sdk-available',
+    ];
+
+    for (const cat of contentCats) {
+      for (const ref of cat.auditRefs) {
+        if (apiOnlyIds.includes(ref.id)) {
+          // These should have been removed by redistributeWeights
+          expect.fail(`API-only audit ${ref.id} should not appear in content profile`);
+        }
+      }
+    }
+  });
+
+  it('should set weight 0 for categories with no active audits in content mode', () => {
+    const contentCats = getCategoriesForSiteType('content');
+
+    const apiQuality = contentCats.find((c) => c.id === 'api-quality');
+    expect(apiQuality?.weight).toBe(0);
+
+    const errorHandling = contentCats.find((c) => c.id === 'error-handling');
+    expect(errorHandling?.weight).toBe(0);
+  });
+
+  it('should keep structured-data category active for content sites', () => {
+    const contentCats = getCategoriesForSiteType('content');
+
+    const structuredData = contentCats.find((c) => c.id === 'structured-data');
+    expect(structuredData?.weight).toBeGreaterThan(0);
+    expect(structuredData?.auditRefs.length).toBeGreaterThan(0);
+  });
+
+  it('should keep discovery category partially active for content sites', () => {
+    const contentCats = getCategoriesForSiteType('content');
+
+    const discovery = contentCats.find((c) => c.id === 'discovery');
+    expect(discovery?.weight).toBeGreaterThan(0);
+    // llms-txt and robots-ai should remain
+    const remainingIds = discovery!.auditRefs.map((r) => r.id);
+    expect(remainingIds).toContain('llms-txt');
+    expect(remainingIds).toContain('robots-ai');
+    // openapi-spec should be removed
+    expect(remainingIds).not.toContain('openapi-spec');
+  });
+
+  it('should return default categories for api sites', () => {
+    const apiCats = getCategoriesForSiteType('api');
+
+    expect(apiCats.length).toBe(DEFAULT_CATEGORIES.length);
+    // All audits should have their default weights
+    for (let i = 0; i < apiCats.length; i++) {
+      expect(apiCats[i]!.auditRefs.length).toBe(DEFAULT_CATEGORIES[i]!.auditRefs.length);
+    }
+  });
+
+  it('should return default categories for hybrid sites', () => {
+    const hybridCats = getCategoriesForSiteType('hybrid');
+    expect(hybridCats.length).toBe(DEFAULT_CATEGORIES.length);
+  });
+
+  it('should return default categories for unknown sites', () => {
+    const unknownCats = getCategoriesForSiteType('unknown');
+    expect(unknownCats.length).toBe(DEFAULT_CATEGORIES.length);
+  });
+});

--- a/src/config/default.ts
+++ b/src/config/default.ts
@@ -1,4 +1,4 @@
-import type { AuditRef } from '../types.js';
+import type { AuditRef, SiteType } from '../types.js';
 
 export interface CategoryConfig {
   id: string;
@@ -8,7 +8,11 @@ export interface CategoryConfig {
   auditRefs: AuditRef[];
 }
 
-export const DEFAULT_CATEGORIES: CategoryConfig[] = [
+/**
+ * Base category definitions with default weights.
+ * These are modified per site type by `getCategoriesForSiteType()`.
+ */
+const BASE_CATEGORIES: CategoryConfig[] = [
   {
     id: 'discovery',
     title: 'Discovery',
@@ -77,6 +81,78 @@ export const DEFAULT_CATEGORIES: CategoryConfig[] = [
     ],
   },
 ];
+
+/**
+ * Audits that are irrelevant for content-only sites.
+ * These get weight 0 (skipped) when site type is 'content'.
+ */
+const API_ONLY_AUDITS = new Set([
+  'openapi-spec',
+  'openapi-valid',
+  'response-format',
+  'response-examples',
+  'content-negotiation',
+  'self-service-auth',
+  'error-codes',
+  'rate-limit-headers',
+  'retry-after',
+  'sdk-available',
+]);
+
+/**
+ * Audits that are less relevant for pure API services.
+ * These get reduced weight when site type is 'api'.
+ * (Reserved for future use)
+ */
+// const CONTENT_AUDIT_BOOSTS: Record<string, number> = {
+//   'json-ld': 10,
+//   'meta-tags': 5,
+//   'semantic-html': 5,
+// };
+
+/**
+ * Returns category configs adjusted for the detected site type.
+ *
+ * - 'api': Use base weights (optimised for API services)
+ * - 'content': Zero-out API-only audits, boost structured data weight
+ * - 'hybrid': Keep base weights as-is
+ * - 'unknown': Keep base weights as-is (conservative default)
+ */
+export function getCategoriesForSiteType(siteType: SiteType): CategoryConfig[] {
+  if (siteType === 'content') {
+    return redistributeWeights(
+      BASE_CATEGORIES.map((cat) => ({
+        ...cat,
+        auditRefs: cat.auditRefs.map((ref) => ({
+          ...ref,
+          weight: API_ONLY_AUDITS.has(ref.id) ? 0 : ref.weight,
+        })),
+      }))
+    );
+  }
+
+  // 'api', 'hybrid', 'unknown' → use base config
+  return structuredClone(BASE_CATEGORIES);
+}
+
+/**
+ * When audits are zeroed out, redistribute the category weight
+ * across remaining audits so the category score remains meaningful.
+ * Also re-balance category weights: categories with zero active audits
+ * get weight 0.
+ */
+function redistributeWeights(categories: CategoryConfig[]): CategoryConfig[] {
+  return categories.map((cat) => {
+    const activeRefs = cat.auditRefs.filter((r) => r.weight > 0);
+    if (activeRefs.length === 0) {
+      return { ...cat, weight: 0, auditRefs: [] };
+    }
+    return { ...cat, auditRefs: activeRefs };
+  });
+}
+
+/** For backwards compat */
+export const DEFAULT_CATEGORIES: CategoryConfig[] = structuredClone(BASE_CATEGORIES);
 
 export const DEFAULT_TIMEOUT = 30_000;
 export const VERSION = '0.3.0';

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export type {
   Recommendation,
   AuditDetails,
   AuditRef,
+  SiteType,
 } from './types.js';
 
 // Base classes (for extensibility)
@@ -32,3 +33,7 @@ export type { ApiGatherResult } from './gatherers/api-gatherer.js';
 // Upload
 export { uploadReport } from './upload.js';
 export type { UploadOptions } from './upload.js';
+
+// Site classification
+export { classifySiteType } from './classifiers/site-type.js';
+export type { SiteTypeResult } from './classifiers/site-type.js';

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -76,6 +76,9 @@ describe('runAudit', () => {
     expect(report.score).toBeGreaterThanOrEqual(0);
     expect(report.score).toBeLessThanOrEqual(100);
 
+    // Verify site type
+    expect(['api', 'content', 'hybrid', 'unknown']).toContain(report.siteType);
+
     // Verify categories
     expect(report.categories).toBeInstanceOf(Array);
     expect(report.categories.length).toBeGreaterThan(0);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,6 +1,7 @@
 import type { AXConfig, AXReport, AXCategory, AuditResult } from './types.js';
 import type { GatherResult } from './gatherers/base-gatherer.js';
-import { DEFAULT_CATEGORIES, VERSION } from './config/default.js';
+import { getCategoriesForSiteType, VERSION } from './config/default.js';
+import { classifySiteType } from './classifiers/site-type.js';
 import {
   calculateCategoryScore,
   calculateOverallScore,
@@ -96,6 +97,9 @@ export async function runAudit(config: AXConfig): Promise<AXReport> {
   artifacts['html'] = await htmlGatherer.gather(config, artifacts);
   artifacts['api'] = await apiGatherer.gather(config, artifacts);
 
+  // Phase 1.5: Classify — detect site type for adaptive scoring
+  const siteTypeResult = classifySiteType(artifacts);
+
   // Phase 2: Audit — run all audits against gathered artifacts
   const allAudits = createAudits();
   const audits: Record<string, AuditResult> = {};
@@ -119,8 +123,9 @@ export async function runAudit(config: AXConfig): Promise<AXReport> {
 
   await Promise.all(auditPromises);
 
-  // Phase 3: Score — calculate category and overall scores
-  const categories: AXCategory[] = DEFAULT_CATEGORIES.map((cat) => ({
+  // Phase 3: Score — use site-type-adapted categories
+  const categoriesConfig = getCategoriesForSiteType(siteTypeResult.type);
+  const categories: AXCategory[] = categoriesConfig.map((cat) => ({
     id: cat.id,
     title: cat.title,
     description: cat.description,
@@ -129,7 +134,7 @@ export async function runAudit(config: AXConfig): Promise<AXReport> {
     auditRefs: cat.auditRefs,
   }));
 
-  const allAuditRefs = DEFAULT_CATEGORIES.flatMap((c) => c.auditRefs);
+  const allAuditRefs = categoriesConfig.flatMap((c) => c.auditRefs);
   const recommendations = generateRecommendations(audits, allAuditRefs);
 
   return {
@@ -137,6 +142,7 @@ export async function runAudit(config: AXConfig): Promise<AXReport> {
     timestamp: new Date().toISOString(),
     version: VERSION,
     score: calculateOverallScore(categories),
+    siteType: siteTypeResult.type,
     categories,
     audits,
     recommendations,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+export type SiteType = 'api' | 'content' | 'hybrid' | 'unknown';
+
 export interface AXConfig {
   url: string;
   timeout?: number;
@@ -40,6 +42,7 @@ export interface AXReport {
   timestamp: string;
   version: string;
   score: number;
+  siteType: SiteType;
   categories: AXCategory[];
   audits: Record<string, AuditResult>;
   recommendations: Recommendation[];

--- a/src/upload.test.ts
+++ b/src/upload.test.ts
@@ -8,6 +8,7 @@ function makeReport(overrides: Partial<AXReport> = {}): AXReport {
     timestamp: '2026-02-20T00:00:00.000Z',
     version: '0.3.0',
     score: 75,
+    siteType: 'unknown',
     categories: [],
     audits: {},
     recommendations: [],


### PR DESCRIPTION
## Summary

Implement site type classification so AX Score can distinguish API services from content sites and avoid irrelevant recommendations.

## What changed

- Added `SiteType` model: `api | content | hybrid | unknown`
- Added `classifySiteType()` using gathered HTTP/HTML signals
  - content signals: article/semantic structure, heading density, JSON-LD content types, meta description, body size
  - api signals: OpenAPI presence, JSON response content-type, API-like links, robots api paths
- Added site-type-aware scoring profile via `getCategoriesForSiteType()`
  - content sites: API-only audits removed/zeroed from scoring
  - api/hybrid/unknown: keep base profile
- Updated `runAudit()` to classify before scoring and apply adaptive categories
- Extended report schema with `siteType`
- Exported classifier and types from package entry

## Tests

- Added new tests:
  - `src/classifiers/__tests__/site-type.test.ts`
  - `src/config/__tests__/default.test.ts`
- Updated existing tests for new `siteType` field
- Validation status:
  - `pnpm lint` ✅
  - `pnpm type-check` ✅
  - `pnpm test` (142/142) ✅

Fixes agentgram/ax-score#49