### PR TITLE
build(deps): bump pnpm/action-setup from 4 to 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Bumps `pnpm/action-setup` from v4 to v6 in `ci.yml` and `publish.yml`
- Replaces #61 which failed CI due to `ERR_PNPM_BROKEN_LOCKFILE` (stale Dependabot branch caused YAML multi-document conflict on merge ref)
- Fresh branch from latest `develop` — lockfile verified clean locally

Closes #61

## Test plan
- [ ] CI passes on both Node 20 and Node 22 matrices
- [ ] `pnpm install --frozen-lockfile` succeeds (no lockfile breakage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)