### PR TITLE
fix(ci): stabilize pnpm/action-setup v6 rollout

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -30,7 +30,7 @@ jobs:
           LABELS=()
 
           # Parse changed files and assign area labels
-          for file in $CHANGED_FILES; do
+          while IFS= read -r file; do
             if [[ $file =~ ^src/gatherers/ ]]; then
               LABELS+=("area: gatherers")
             elif [[ $file =~ ^src/audits/ ]]; then
@@ -52,18 +52,20 @@ jobs:
             if [[ $file =~ package\.json$ ]] || [[ $file =~ pnpm-lock\.yaml$ ]]; then
               LABELS+=("dependencies")
             fi
-          done
+          done < <(jq -r '.[]' <<< "$CHANGED_FILES")
 
           # Check for breaking changes
           if [[ "$PR_TITLE" =~ BREAKING ]] || [[ "$PR_BODY" =~ BREAKING ]]; then
             LABELS+=("breaking-change")
           fi
 
-          # Remove duplicates and format as JSON array
-          UNIQUE_LABELS=($(printf '%s\n' "${LABELS[@]}" | sort -u))
-          LABELS_JSON=$(printf '%s\n' "${UNIQUE_LABELS[@]}" | jq -R . | jq -s .)
+          LABELS_JSON=$(printf '%s\n' "${LABELS[@]}" | jq -R . | jq -s 'map(select(length > 0)) | unique')
 
-          echo "labels=$LABELS_JSON" >> "$GITHUB_OUTPUT"
+          {
+            echo 'labels<<EOF'
+            echo "$LABELS_JSON"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Apply labels
         if: fromJson(steps.labels.outputs.labels)[0] != null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- upgrade `pnpm/action-setup` to v6 in CI and publish workflows on a fresh branch from `develop`
- fix auto-label output generation so labels with spaces like `area: infrastructure` no longer break the workflow output format
- supersedes the broken #61 and #62 path by carrying the same workflow upgrade on a clean branch

## Validation
- `pnpm install --frozen-lockfile`
- local shell check for the auto-label JSON output path

Closes #61