### PR TITLE
fix: pnpm-lock.yaml tinyglobby@0.2.17 중복 키 제거 (CI 수정)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1285,10 +1285,6 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
-  tinyglobby@0.2.17:
-    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
-    engines: {node: '>=12.0.0'}
-
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
@@ -2497,11 +2493,6 @@ snapshots:
   tinyexec@1.2.4: {}
 
   tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
-  tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4


### PR DESCRIPTION
## 원인

PR #80 (dependabot `actions/checkout` v6→v7)에서 CI가 실패한 진짜 원인은 `actions/checkout` 버전이 아니라 **`pnpm-lock.yaml`의 YAML duplicated mapping key**였습니다.

```
ERR_PNPM_BROKEN_LOCKFILE  The lockfile at "pnpm-lock.yaml" is broken: duplicated mapping key (1288:3)
```

- `packages` 섹션: `tinyglobby@0.2.17`이 두 번 선언됨
- `snapshots` 섹션: `tinyglobby@0.2.17`이 두 번 선언됨

이 broken lockfile은 `develop` 브랜치에 이미 존재했으나, CI trigger가 `push: [main]`만 포함되어 발견되지 않았습니다. dependabot PR이 develop 타겟 PR을 트리거해 처음으로 드러남.

## 수정 내용

- `pnpm-lock.yaml` packages 섹션에서 `tinyglobby@0.2.17` 중복 항목 제거
- `pnpm-lock.yaml` snapshots 섹션에서 `tinyglobby@0.2.17` 중복 항목 제거

## 다음 조치

이 PR 머지 후 PR #80 재실행하면 CI 통과 가능.